### PR TITLE
Add Len() to common interface

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -257,7 +257,9 @@ func (c *Cache[K, V]) Delete(key K) {
 
 // Len returns the number of items in the cache.
 func (c *Cache[K, V]) Len() int {
-	return len(c.Keys())
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cache.Len()
 }
 
 // Contains reports whether key is within cache.

--- a/cache.go
+++ b/cache.go
@@ -23,6 +23,8 @@ type Interface[K comparable, V any] interface {
 	Keys() []K
 	// Delete deletes the item with provided key from the cache.
 	Delete(key K)
+	// Len returns the number of items in the cache.
+	Len() int
 }
 
 var (
@@ -251,6 +253,13 @@ func (c *Cache[K, V]) Delete(key K) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.cache.Delete(key)
+}
+
+// Len returns the number of items in the cache.
+func (c *Cache[K, V]) Len() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.cache.Len()
 }
 
 // Contains reports whether key is within cache.

--- a/cache.go
+++ b/cache.go
@@ -257,9 +257,7 @@ func (c *Cache[K, V]) Delete(key K) {
 
 // Len returns the number of items in the cache.
 func (c *Cache[K, V]) Len() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.cache.Len()
+	return len(c.Keys())
 }
 
 // Contains reports whether key is within cache.

--- a/example_test.go
+++ b/example_test.go
@@ -123,6 +123,16 @@ func ExampleCache_Keys() {
 	// [a b c]
 }
 
+func ExampleCache_Len() {
+	c := cache.New(cache.AsLFU[string, int]())
+	c.Set("a", 1)
+	c.Set("b", 1)
+	c.Set("c", 1)
+	fmt.Println(c.Len())
+	// Output:
+	// 3
+}
+
 func ExampleCache_Contains() {
 	c := cache.New(cache.AsLRU[string, int]())
 	c.Set("a", 1)

--- a/policy/simple/example_test.go
+++ b/policy/simple/example_test.go
@@ -2,6 +2,7 @@ package simple_test
 
 import (
 	"fmt"
+	"testing"
 
 	"github.com/Code-Hex/go-generics-cache/policy/simple"
 )
@@ -46,4 +47,24 @@ func ExampleCache_Keys() {
 	// foo
 	// bar
 	// baz
+}
+
+func BenchmarkLenWithKeys(b *testing.B) {
+	c := simple.NewCache[string, int]()
+	c.Set("foo", 1)
+	c.Set("bar", 2)
+	c.Set("baz", 3)
+	for i := 0; i < b.N; i++ {
+		var _ = len(c.Keys())
+	}
+}
+
+func BenchmarkJustLen(b *testing.B) {
+	c := simple.NewCache[string, int]()
+	c.Set("foo", 1)
+	c.Set("bar", 2)
+	c.Set("baz", 3)
+	for i := 0; i < b.N; i++ {
+		var _ = c.Len()
+	}
 }

--- a/policy/simple/simple.go
+++ b/policy/simple/simple.go
@@ -59,3 +59,8 @@ func (c *Cache[K, _]) Keys() []K {
 func (c *Cache[K, V]) Delete(key K) {
 	delete(c.items, key)
 }
+
+// Len returns the number of items in the cache.
+func (c *Cache[K, V]) Len() int {
+	return len(c.items)
+}


### PR DESCRIPTION
Len() method is useful in common interface and is simple to implement.
- implement Len for simple cache, it was the only policy missing the method

Fixes  https://github.com/Code-Hex/go-generics-cache/issues/43