### PR TITLE
Add a GetDefault method.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -214,6 +214,22 @@ func (c *Cache[K, V]) Get(key K) (value V, ok bool) {
 	return item.Value, true
 }
 
+// GetDefault atomically gets a key's value from the cache, or if the
+// key is not present, sets the given value.
+func (c *Cache[K, V]) GetDefault(key K, val V, opts ...ItemOption) V {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	item, ok := c.cache.Get(key)
+
+	if !ok || item.Expired() {
+		item := newItem(key, val, opts...)
+		c.cache.Set(key, item)
+		return val
+	}
+
+	return item.Value
+}
+
 // DeleteExpired all expired items from the cache.
 func (c *Cache[K, V]) DeleteExpired() {
 	c.mu.Lock()

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/Code-Hex/go-generics-cache
+module github.com/bn-jbowers/go-generics-cache
 
 go 1.18
 


### PR DESCRIPTION
This adds a GetDefault method, which will either return the value in the cache, or if it is not present, set it with the passed-in value, returning whichever value ends up in the cache.

This must be done inside the cache because calling .Get, then .Set if the value is not present, is a TOCTOU (Time Of Check to Time Of Use) problem; something else may have set that value in the meantime. Only the cache can perform this operation atomically and safely.