### PR TITLE
chore: remove golang.org/x/exp dependency

### DIFF
--- a/constraint.go
+++ b/constraint.go
@@ -1,8 +1,9 @@
 package cache
 
-import "golang.org/x/exp/constraints"
-
 // Number is a constraint that permits any numeric types.
 type Number interface {
-	constraints.Integer | constraints.Float | constraints.Complex
+	~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64 |
+		~complex64 | ~complex128
 }

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/Code-Hex/go-generics-cache
 
 go 1.18
-
-require golang.org/x/exp v0.0.0-20220328175248-053ad81199eb

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-golang.org/x/exp v0.0.0-20220328175248-053ad81199eb h1:pC9Okm6BVmxEw76PUu0XUbOTQ92JX11hfvqTjAV3qxM=
-golang.org/x/exp v0.0.0-20220328175248-053ad81199eb/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=


### PR DESCRIPTION
`constraints` package is not planned to land in std : https://github.com/golang/go/issues/50792

Would you consider removing the dependency?

Thanks!